### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             sudo apt update
             sudo apt install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
-                             libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev libmatio-dev
+                             libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python3-dev valgrind libassimp-dev libmatio-dev
 
         - name: Cache Source-based dependencies  [Ubuntu/macOS]
           if: steps.cache-source-deps.outputs.cache-hit != 'true' && (contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macOS'))


### PR DESCRIPTION
This PR addresses latest failures in the CI (e.g. https://github.com/ami-iit/element_weight-retargeting/actions/runs/3672081372) due to the apt-depencencies build job. Apparently the package `python-dev` has been removed in favor of either `python3-dev` or `python2-dev`. 